### PR TITLE
use typedefs instead of inheriting from iterator

### DIFF
--- a/include/spatial_hash/layer.h
+++ b/include/spatial_hash/layer.h
@@ -34,7 +34,9 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -204,10 +206,14 @@ class Layer {
 
  public:
   // Iterators.
-  class iterator
-      : public std::iterator<std::forward_iterator_tag, BlockT, std::ptrdiff_t, BlockT*, BlockT&> {
+  class iterator {
    public:
     using MapIt = typename BlockMap::iterator;
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = BlockT;
+    using pointer = BlockT*;
+    using reference = Block&;
 
     explicit iterator(MapIt it) : it_(it) {}
     iterator& operator++() {
@@ -228,13 +234,14 @@ class Layer {
     MapIt it_;
   };
 
-  class const_iterator : public std::iterator<std::forward_iterator_tag,
-                                              const BlockT,
-                                              std::ptrdiff_t,
-                                              BlockT const*,
-                                              const BlockT&> {
+  class const_iterator {
    public:
     using MapIt = typename BlockMap::const_iterator;
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = const BlockT;
+    using pointer = const BlockT*;
+    using reference = const Block&;
 
     explicit const_iterator(MapIt it) : it_(it) {}
     const_iterator& operator++() {

--- a/include/spatial_hash/voxel_layer.h
+++ b/include/spatial_hash/voxel_layer.h
@@ -276,12 +276,14 @@ class VoxelLayer : protected Grid<GlobalIndex>, public BlockLayer<BlockT> {
         : blocks_(blocks), num_voxels_(num_voxels) {}
     virtual ~VoxelIterable() = default;
 
-    class iterator : public std::iterator<std::forward_iterator_tag,
-                                          VoxelType,
-                                          std::ptrdiff_t,
-                                          VoxelType*,
-                                          VoxelType&> {
+    class iterator {
      public:
+      using iterator_category = std::forward_iterator_tag;
+      using difference_type = std::ptrdiff_t;
+      using value_type = VoxelType;
+      using pointer = VoxelType*;
+      using reference = VoxelType&;
+
       iterator(MapIt map_it, MapIt map_end, size_t voxel_idx, size_t num_voxels)
           : map_it_(map_it), map_end_(map_end), voxel_idx_(voxel_idx), num_voxels_(num_voxels) {}
 
@@ -315,12 +317,14 @@ class VoxelLayer : protected Grid<GlobalIndex>, public BlockLayer<BlockT> {
       const size_t num_voxels_;
     };
 
-    class const_iterator : public std::iterator<std::forward_iterator_tag,
-                                                VoxelType,
-                                                std::ptrdiff_t,
-                                                VoxelType*,
-                                                VoxelType&> {
+    class const_iterator {
      public:
+      using iterator_category = std::forward_iterator_tag;
+      using difference_type = std::ptrdiff_t;
+      using value_type = const VoxelType;
+      using pointer = const VoxelType*;
+      using reference = const VoxelType&;
+
       const_iterator(MapIt map_it, MapIt map_end, size_t voxel_idx, size_t num_voxels)
           : map_it_(map_it), map_end_(map_end), voxel_idx_(voxel_idx), num_voxels_(num_voxels) {}
 


### PR DESCRIPTION
@Schmluk Fixes warnings about inheriting from deprecated `std::iterator`